### PR TITLE
remove 'http://' from host name

### DIFF
--- a/config.py-example
+++ b/config.py-example
@@ -1,7 +1,7 @@
 signature   = "" # AWS secret access key
 accesskey   = "" # AWS access key ID
 sandbox     = True # if true, put on workersandbox.mturk.com
-host        = "http://localhost" 
+host        = "localhost" 
 port        = 8080
 localhost   = "{0}:{1}".format(host, port) # your local host
 database    = "mysql://root@localhost/vatic" # server://user:pass@localhost/dbname


### PR DESCRIPTION
somehow resolves error 'socket gaierror errno 2 name or service not known' which appears when trying to run 'python start_server.py'
